### PR TITLE
Minor updates to Disable_SMBv1_3 Script

### DIFF
--- a/Disable_SMBv1_3.ps1
+++ b/Disable_SMBv1_3.ps1
@@ -4,12 +4,12 @@
 # Creation Date:   05/16/2018
 # Author:          Eric C. Mattoon (ermatt)
 #
-#   Version:       01.00.0003
-#   Version Date:  05/16/2018
+#   Version:       01.00.0004
+#   Version Date:  05/13/2019
 # 
 # Description:     Purpose of this script is to disable SMBv1:
 #
-#                  First check if SMBv2 &/or SMBv3 is turned on:
+#                  First check if SMBv2 is turned on:
 #                       1) If it is not, enable it so we don't lose the connection
 #                       2) Otherwise we are good to disable
 #
@@ -17,8 +17,9 @@
 
 #Initialize whether SMBv1 & SMBv2 are turned on for the current machine
 
-$smbv1Found = Get-SmbServerConfiguration | Select -ExpandProperty EnableSMB1Protocol
-$smbv2Found = Get-SmbServerConfiguration | Select -ExpandProperty EnableSMB2Protocol
+$smbConfig = Get-SmbServerConfiguration
+$smbv1Found = $smbConfig | Select-Object -ExpandProperty EnableSMB1Protocol
+$smbv2Found = $smbConfig | Select-Object -ExpandProperty EnableSMB2Protocol
 
 # If we find SMBv1
 if($smbv1Found){
@@ -30,15 +31,21 @@ if($smbv1Found){
     # Otherwise we need to turn on SMBv2 before we turn off SMBv1
     else{
         Set-SmbServerConfiguration -EnableSMB2Protocol $true -Force
-        Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force
+        
+        # Validate the protocol, we don't want to break connection if SMBv2 failed to enable
+        $smbv2Found = $smbConfig | Select-Object -ExpandProperty EnableSMB2Protocol
+        If($smbv2Found) {
+            Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force
+        }     
     }
 }
 else{
     # Don't do anything, SMBv1 is off after all...
 }
 
-$smbv1Found = Get-SmbServerConfiguration | Select -ExpandProperty EnableSMB1Protocol
-$smbv2Found = Get-SmbServerConfiguration | Select -ExpandProperty EnableSMB2Protocol
+$smbConfig = Get-SmbServerConfiguration
+$smbv1Found = $smbConfig | Select-Object -ExpandProperty EnableSMB1Protocol
+$smbv2Found = $smbConfig | Select-Object -ExpandProperty EnableSMB2Protocol
 
 $output = "SMBv1 = $smbv1Found, SMBv2 = $smbv2Found"
 


### PR DESCRIPTION
Minor updates:
- Removed references to SMBv3 (since nothing was actually being done with v3).
- Changed calls out to Get-SmbServerConfiguration to run once at top and once at bottom, and then pull properties from that call instead of calling once for v1 and once for v2.
- Ensure v2 is active before we disable v1.
- Updated Version & Date.  
